### PR TITLE
Sign with prepend PK

### DIFF
--- a/aug_scheme_mpl.go
+++ b/aug_scheme_mpl.go
@@ -13,7 +13,11 @@ type AugSchemeMPL struct{}
 
 // Sign 签名
 func (asm *AugSchemeMPL) Sign(sk PrivateKey, message []byte) []byte {
-	return bls12381.NewG2().ToCompressed(coreSignMpl(sk, message, AugSchemeDst))
+	return bls12381.NewG2().ToCompressed(coreSignMpl(sk, nil, message, AugSchemeDst))
+}
+
+func (asm *AugSchemeMPL) SignWithPrependPK(sk PrivateKey, prependPK PublicKey, message []byte) []byte {
+	return bls12381.NewG2().ToCompressed(coreSignMpl(sk, &prependPK, message, AugSchemeDst))
 }
 
 // Verify 验证
@@ -36,8 +40,11 @@ func (asm *AugSchemeMPL) AggregateVerify(pks [][]byte, messages [][]byte, sig []
 	return coreAggregateVerify(pks, messages, sig, AugSchemeDst)
 }
 
-func coreSignMpl(sk PrivateKey, message, dst []byte) *bls12381.PointG2 {
+func coreSignMpl(sk PrivateKey, prependPK *PublicKey, message, dst []byte) *bls12381.PointG2 {
 	pk := sk.GetPublicKey()
+	if prependPK != nil {
+		pk = *prependPK
+	}
 
 	g2Map := bls12381.NewG2()
 


### PR DESCRIPTION
At Chia official implementation on bls signature, there is overloading `Sign` function, that accept `prepend_pk` as parameter ([link](https://github.com/Chia-Network/bls-signatures/blob/f9db7faa370c4743e48be8a9823232e4d906c4d0/src/schemes.cpp#L329)). This overloading function is implemented in several places at Chia official blockchain. [Here](https://github.com/Chia-Network/chia-blockchain/blob/39ab18cb9028a330644d3117cf716b319ee64a45/chia/farmer/farmer_api.py#L194) and [there](https://github.com/Chia-Network/chia-blockchain/blob/39ab18cb9028a330644d3117cf716b319ee64a45/chia/harvester/harvester_api.py#L273) is some implementation.

This PR try to add that implementation.